### PR TITLE
Add various default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,51 @@ POJO generation for killbill-api
 
 ## Usage
 
-POJO generation for killbill-api is done with the tool `pojogen`. It takes in a XML file that contains the POJO generation [settings](doc/SETTINGS.md).
+POJO generation for killbill-api is done with the tool `pojogen`.
 
 To run the tool:
 
 ```
-java -jar pojogen.jar settings.xml
+java -jar pojogen.jar
 
 ```
-Please look at the [example](doc/EXAMPLE.md) for details on how to generate POJOs for killbill-api.
+
+- It expects that there's [killbill-api](https://github.com/killbill/killbill-api/) project in `./killbill-api` directory. 
+  This can be overridden by ` --input` option. 
+
+- It expects that you've been working with `killbill-api` for sometimes, thus your local maven repository contains all 
+  JAR required by `killbill-api` project, and `pojogen` will scan all library in your maven repository. Furthermore, you 
+  may find there's an error that caused by some not-related JARs that does not exist. Just delete those JARs, as maven 
+  always re-downloaded those JARs when needed. If this give too much trouble, you can: 
+  `mvn dependency:copy-dependencies -DoutputDirectory=../lib -Dhttps.protocols="TLSv1.2" -f ./killbill-api/pom.xml` and 
+  set ` --input-dependencies=lib`.
+  As explained above, this is can be overridden by ` --input-dependencies` option.
+
+- It will try to generate all packages in `killbill-api`. 
+  This can be overridden by ` --input-packages` options, separated by comma.
+
+- It expects that there's [killbill-plugin-framework-java](https://github.com/killbill/killbill-plugin-framework-java/) 
+  project in `./killbill-plugin-framework-java` directory. 
+  This can be overridden by ` --output` option.
+
+- It expects that your ` --output` is maven based project, thus it will generate resources files in `src/main/resources` 
+  directory.
+  This can be overridden by ` --output-resources` option.
+
+- All generated classes will be placed in `boilerplate` sub-package in project defined in ` --output` option. 
+  This can be overridden by ` --output-subpackage` option.
+
+- It expects that your ` --output` is maven based project, thus it will generate test files in `src/test/java` directory.
+  This can be overridden by ` --output-test` option.
+
+
+For all available options, you can use:
+```
+java -jar pojogen.jar --help
+```
+
+Please look at the [example](doc/EXAMPLE.md) for edge cases on how to generate POJOs for killbill-api. For more about 
+`settings.xml` file, refers to [settings](doc/SETTINGS.md) 
 
 
 ## Build

--- a/pom.xml
+++ b/pom.xml
@@ -1,130 +1,158 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2022-2023 The Billing Project, LLC
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-<modelVersion>4.0.0</modelVersion>
-<groupId>org.kill-bill.billing.tool</groupId>
-<artifactId>pojogen</artifactId>
-<version>1.1-SNAPSHOT</version>
-<name>pojogen</name>
-<properties>
-  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <maven.compiler.source>11</maven.compiler.source>
-  <maven.compiler.target>11</maven.compiler.target>
-</properties>
-<dependencies>
-  <dependency>
-    <groupId>com.github.javaparser</groupId>
-    <artifactId>javaparser-core</artifactId>
-    <version>3.24.0</version>
-  </dependency>
-  <dependency>
-    <groupId>com.github.javaparser</groupId>
-    <artifactId>javaparser-symbol-solver-core</artifactId>
-    <version>3.24.0</version>
-  </dependency>
-  <dependency>
-    <groupId>org.freemarker</groupId>
-    <artifactId>freemarker</artifactId>
-    <version>2.3.31</version>
-  </dependency>
-  <dependency>
-    <groupId>commons-io</groupId>
-    <artifactId>commons-io</artifactId>
-    <version>2.11.0</version>
-  </dependency>
-  <dependency>
-    <groupId>com.fasterxml.jackson.dataformat</groupId>
-    <artifactId>jackson-dataformat-xml</artifactId>
-    <version>2.13.1</version>
-  </dependency>
-  <dependency>
-    <groupId>info.picocli</groupId>
-    <artifactId>picocli</artifactId>
-    <version>4.6.2</version>
-  </dependency>
-  <dependency>
-    <groupId>org.apache.logging.log4j</groupId>
-    <artifactId>log4j-core</artifactId>
-    <version>2.17.1</version>
-  </dependency>
-  <dependency>
-    <groupId>org.apache.logging.log4j</groupId>
-    <artifactId>log4j-api</artifactId>
-    <version>2.17.1</version>
-  </dependency>
-</dependencies>
-<build>
-  <finalName>${project.artifactId}</finalName>
-  <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
-    <plugins>
-      <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>3.1.0</version>
-      </plugin>
-      <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.2</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
-      </plugin>
-      <!--
-        <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
-        </plugin>
-      -->
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
-        </plugin>
-        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.2.2</version>
-          <configuration>
-            <archive>
-              <manifest>
-                <mainClass>org.killbill.billing.tool.pojogen.Main</mainClass>
-              </manifest>
-            </archive>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.4</version>
-          <executions>
-            <execution>
-              <phase>package</phase>
-              <goals>
-                <goal>shade</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+  The Billing Project licenses this file to you under the Apache License,
+  version 2.0 (the "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at:
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  License for the specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.kill-bill.billing.tool</groupId>
+    <artifactId>pojogen</artifactId>
+    <version>1.2-SNAPSHOT</version>
+    <name>pojogen</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>3.24.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-symbol-solver-core</artifactId>
+            <version>3.24.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>2.3.31</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.19.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.19.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+            <plugins>
+                <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.1</version>
+                </plugin>
+                <!--
+                  <plugin>
+                  <artifactId>maven-jar-plugin</artifactId>
+                  <version>3.0.2</version>
+                  </plugin>
+                -->
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+                <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.7.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.2</version>
+                    <configuration>
+                        <archive>
+                            <manifest>
+                                <mainClass>org.killbill.billing.tool.pojogen.Main</mainClass>
+                            </manifest>
+                        </archive>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.2.4</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/src/main/java/org/killbill/billing/tool/pojogen/SettingsLoader.java
+++ b/src/main/java/org/killbill/billing/tool/pojogen/SettingsLoader.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.tool.pojogen;
+
+import org.apache.commons.io.FileUtils;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+class SettingsLoader {
+
+    private static final String SEPARATOR = System.getProperty("file.separator");
+    static final String MAVEN_SRC_DIR = "src" + SEPARATOR + "main" + SEPARATOR + "java";
+    static final String MAVEN_RES_DIR = "src" + SEPARATOR + "main" + SEPARATOR + "resources";
+    static final String MAVEN_TES_DIR = "src" + SEPARATOR + "test" + SEPARATOR + "java";
+
+    private final Log log = new Log(SettingsLoader.class);
+    private final Settings settings;
+
+    /**
+     * Create an instance with optional settings.xml . If null, then setting configuration will load from default
+     * settings.xml in the classpath. If user try to set to non-existent file, then exception.
+     */
+    SettingsLoader(@Nullable final File settingsXml) throws Exception {
+        if (settingsXml == null) {
+            settings = getFromClasspath();
+        } else if (!settingsXml.exists()) {
+            throw new Exception("Try to use settingsXml: '" + settingsXml.getAbsolutePath() + "' but it's not exist");
+        } else {
+            settings = Settings.read(settingsXml);
+        }
+
+        if (settings.getDependencies() == null ||
+            settings.getDependencies().isEmpty() ||
+            settings.getDependencies().get(0) == null /* this one is weird: value is [null] */) {
+            // Set dependency to local maven repository by default
+            settings.setDependencyDirectories(List.of(new File(FileUtils.getUserDirectoryPath() + SEPARATOR + ".m2")));
+        }
+    }
+
+    private Settings getFromClasspath() throws Exception {
+        File file = Files.createTempFile("", "").toFile();
+        FileUtils.copyInputStreamToFile(Objects.requireNonNull(getClass().getResourceAsStream("/settings.xml")), file);
+        return Settings.read(file);
+    }
+
+    void overrideInputDependencyDirectory(final String inputDependencies) {
+        if (isStringExist(inputDependencies)) {
+            final File file = new File(inputDependencies);
+            if (isFileExist(file)) {
+                log.trace("Override inputDependencies directory to: " + inputDependencies);
+                settings.setDependencyDirectories(List.of(file));
+            } else {
+                throw new IllegalArgumentException("Set '--input-dependencies' to non-existent directory: " + inputDependencies);
+            }
+        }
+    }
+
+    void overrideInputDirectory(final String input) {
+        if (isStringExist(input)) {
+            final File inputFile = new File(input);
+            if (isFileExist(inputFile)) {
+                log.trace("Override input directory to: " + input);
+                settings.setSources(Collections.singletonList(inputFile));
+            } else {
+                throw new IllegalArgumentException("Set '--input' to non-existent directory");
+            }
+        }
+    }
+
+    void overrideInputPackagesDirectory(String[] inputPackages) {
+        if (inputPackages != null && inputPackages.length > 0) {
+            final List<String> packages = List.of(inputPackages);
+            log.trace("Set '--input-packages' directory to: " + packages);
+            settings.setPackages(packages);
+        }
+    }
+
+    void overrideOutputDirectory(final String output) {
+        if (isStringExist(output)) {
+            final File file = new File(output);
+            if (isFileExist(file)) {
+                log.trace("Set '--output' directory to: " + output);
+                settings.setOutput(file);
+
+                String location = file.getAbsolutePath();
+                if (location.contains(MAVEN_SRC_DIR)) {
+                    overrideOutputResourcesDirectory(location.replace(MAVEN_SRC_DIR, MAVEN_RES_DIR), false);
+                    overrideOutputTestDirectory(location.replace(MAVEN_SRC_DIR, MAVEN_TES_DIR), false);
+                }
+            } else {
+                throw new IllegalArgumentException("Set '--output' to non-existent directory");
+            }
+        }
+    }
+
+    public void overrideOutputSubpackageDirectory(String outputSubPackage) {
+        if (outputSubPackage != null && !outputSubPackage.isBlank()) {
+            log.trace("Override outputSubPackage directory to: " + outputSubPackage);
+            settings.setSubpackage(outputSubPackage);
+        }
+    }
+
+    void overrideOutputResourcesDirectory(final String outputResources) {
+        overrideOutputResourcesDirectory(outputResources, true);
+    }
+
+    void overrideOutputResourcesDirectory(final String outputResources, final boolean exceptionIfNotExist) {
+        if (isStringExist(outputResources)) {
+            final File file = new File(outputResources);
+            if (isFileExist(file)) {
+                log.trace("Set '--output-resources' directory to: " + outputResources);
+                settings.setResource(file);
+            } else {
+                final String msg = "Set '--output-resources' to non-existent directory.";
+                if (exceptionIfNotExist) {
+                    throw new IllegalArgumentException(msg);
+                } else {
+                    log.warn(msg + " The output likely maven project, but doesn't have 'src/main/resources' directory. Skip resources generation");
+                }
+            }
+        }
+    }
+
+    void overrideOutputTestDirectory(final String test) {
+        overrideOutputTestDirectory(test, true);
+    }
+
+    void overrideOutputTestDirectory(final String test, final boolean exceptionIfNotExist) {
+        if (isStringExist(test)) {
+            final File file = new File(test);
+            if (isFileExist(file)) {
+                log.trace("Set '--output-test' directory to: " + test);
+                settings.setTest(file);
+            } else {
+                final String msg = "Set '--output-test' to non-existent directory";
+                if (exceptionIfNotExist) {
+                    throw new IllegalArgumentException(msg);
+                } else {
+                    log.warn(msg + " The output likely maven project, but doesn't have 'src/test/java' directory. Skip test generation");
+                }
+            }
+        }
+    }
+
+    Settings getSettings() {
+        return settings;
+    }
+
+    private boolean isFileExist(final File file) {
+        return file != null && file.exists();
+    }
+
+    private boolean isStringExist(String s) {
+        return s != null && !s.isBlank();
+    }
+}

--- a/src/main/resources/settings.xml
+++ b/src/main/resources/settings.xml
@@ -21,13 +21,13 @@
       In a Java Package Structure, each subdirectory of corresponds to a Java package.
   -->
   <sourceDirectories>
-    <sourceDirectory>input/project/src/main/java</sourceDirectory>
+    <sourceDirectory>./killbill-api/src/main/java</sourceDirectory>
   </sourceDirectories>
   <!--
-    The directories containing Jar dependencies of the source code.
+    The directories containing Jar dependencies of the source code. If empty, it will try to set to local maven repository.
   -->
   <dependencyDirectories>
-    <dependencyDirectory>input/lib</dependencyDirectory>
+    <dependencyDirectory></dependencyDirectory>
   </dependencyDirectories>
   <!--
     The subpackage to place the generated classes.
@@ -44,15 +44,15 @@
   <!--
     The directory to output the Java Package Structure of the POJOs.
   -->
-  <outputDirectory>output/project/src/main/java</outputDirectory>
+  <outputDirectory>./killbill-plugin-framework-java/src/main/java</outputDirectory>
   <!--
     The directory to place the generated resources.
   -->
-  <resourceDirectory>output/project/src/main/resources</resourceDirectory>
+  <resourceDirectory>./killbill-plugin-framework-java/src/main/resources</resourceDirectory>
   <!--
-    The directory to output the Java Package Structure of the the test units.
+    The directory to output the Java Package Structure of the test units.
   -->
-  <testDirectory>output/project/src/test/java</testDirectory>
+  <testDirectory>./killbill-plugin-framework-java/src/test/java</testDirectory>
   <!--
     Generate output for the following packages.
   -->

--- a/src/test/java/org/killbill/billing/tool/pojogen/TestSettingsLoader.java
+++ b/src/test/java/org/killbill/billing/tool/pojogen/TestSettingsLoader.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.tool.pojogen;
+
+import com.google.common.io.Resources;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+public class TestSettingsLoader {
+
+    private SettingsLoader getSettingsLoader(final String settingsXml) {
+        try {
+            final File file = settingsXml == null ?
+                    null :
+                    new File(Resources.getResource(settingsXml).toURI());
+            return new SettingsLoader(file);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test(groups = "fast")
+    void constructor() {
+        SettingsLoader settingsLoader = getSettingsLoader(null);
+        Settings settings = settingsLoader.getSettings();
+
+        Assert.assertNotNull(settings.getSources());
+        Assert.assertFalse(settings.getSources().isEmpty());
+        Assert.assertEquals(settings.getSources().get(0), new File("./killbill-api/src/main/java"));
+
+        Assert.assertNotNull(settings.getDependencies());
+        Assert.assertFalse(settings.getDependencies().isEmpty());
+        Assert.assertNotNull(settings.getDependencies().get(0));
+        Assert.assertTrue(settings.getDependencies().get(0).getPath().contains("m2"));
+
+        Assert.assertNotNull(settings.getOutput());
+        Assert.assertEquals(settings.getOutput(), new File("./killbill-plugin-framework-java/src/main/java"));
+
+        settingsLoader = getSettingsLoader("settings_with-dependency.xml");
+        settings = settingsLoader.getSettings();
+        Assert.assertEquals(settings.getDependencies().size(), 1);
+        Assert.assertEquals(settings.getDependencies().get(0), new File("./lib"));
+    }
+
+    @Test(groups = "fast")
+    void overrideInputDependencyDirectory() {
+        final SettingsLoader settingsLoader = getSettingsLoader(null);
+        Assert.assertTrue(settingsLoader.getSettings().getDependencies().get(0).getPath().contains("m2"));
+
+        settingsLoader.overrideInputDependencyDirectory("src"); // This is maven its own structure
+        Assert.assertFalse(settingsLoader.getSettings().getDependencies().get(0).getPath().contains("m2"));
+        Assert.assertTrue(settingsLoader.getSettings().getDependencies().get(0).getPath().contains("src"));
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> settingsLoader.overrideOutputDirectory("non-existent"));
+    }
+
+    @Test(groups = "fast")
+    void overrideInputDirectory() {
+        final SettingsLoader settingsLoader = getSettingsLoader(null);
+        Assert.assertTrue(settingsLoader.getSettings().getSources().get(0).getPath().contains("killbill-api"));
+
+        settingsLoader.overrideInputDirectory("src");
+        Assert.assertFalse(settingsLoader.getSettings().getSources().get(0).getPath().contains("killbill-api"));
+        Assert.assertTrue(settingsLoader.getSettings().getSources().get(0).getPath().contains("src"));
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> settingsLoader.overrideInputDirectory("non-existent"));
+    }
+
+    @Test(groups = "fast")
+    void overrideInputPackagesDirectory() {
+        final SettingsLoader settingsLoader = getSettingsLoader(null);
+        // Default settings.xml contains all killbill-api packages
+        Assert.assertTrue(settingsLoader.getSettings().getPackages().size() > 30);
+
+        settingsLoader.overrideInputPackagesDirectory(new String[] {"com.acme.foo", "com.acme.helper", "com.acme.blah"});
+        Assert.assertEquals(settingsLoader.getSettings().getPackages().size(), 3);
+    }
+
+    @Test(groups = "fast")
+    void overrideOutputDirectory() {
+        final SettingsLoader settingsLoader = getSettingsLoader(null);
+        Assert.assertTrue(settingsLoader.getSettings().getOutput().getPath().contains("killbill-plugin-framework-java"));
+
+        settingsLoader.overrideOutputDirectory("src"); // This project "src" directory
+        Assert.assertTrue(settingsLoader.getSettings().getOutput().getPath().contains("src"));
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> settingsLoader.overrideOutputDirectory("non-existent"));
+    }
+
+    @Test(groups = {"unix"}) // To avoid having a path/separator problem with windows based machine.
+    void overrideOutputDirectoryWithMavenStructure() {
+        final SettingsLoader settingsLoader = getSettingsLoader(null);
+
+        settingsLoader.overrideOutputDirectory("../killbill/util/src/main/java");
+        Assert.assertTrue(settingsLoader.getSettings().getOutput().getPath().contains(SettingsLoader.MAVEN_SRC_DIR));
+
+        // Make sure that #overrideOutputResourcesDirectory() and #overrideOutputTestDirectory() called
+        Assert.assertTrue(settingsLoader.getSettings().getResource().getPath().contains(SettingsLoader.MAVEN_RES_DIR));
+        Assert.assertTrue(settingsLoader.getSettings().getTest().getPath().contains(SettingsLoader.MAVEN_TES_DIR));
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> settingsLoader.overrideOutputDirectory("non-existent"));
+    }
+
+    @Test(groups = "fast")
+    void overrideOutputSubpackageDirectory() {
+        final SettingsLoader settingsLoader = getSettingsLoader(null);
+        Assert.assertEquals(settingsLoader.getSettings().getSubpackage(), "boilerplate");
+
+        settingsLoader.overrideOutputSubpackageDirectory("impl");
+        Assert.assertEquals(settingsLoader.getSettings().getSubpackage(), "impl");
+    }
+
+    @Test
+    void overrideOutputResourcesDirectory() {
+        final SettingsLoader settingsLoader = getSettingsLoader(null);
+        Assert.assertTrue(settingsLoader.getSettings().getResource().getPath().contains("resources"));
+
+        settingsLoader.overrideOutputResourcesDirectory("src"); // This project "src" directory
+        Assert.assertTrue(settingsLoader.getSettings().getResource().getPath().contains("src"));
+        // Make sure it's not pointing to "killbill-plugin-framework-java/src/main/resources" anymore
+        Assert.assertFalse(settingsLoader.getSettings().getResource().getPath().contains("killbill-plugin-framework-java"));
+        Assert.assertFalse(settingsLoader.getSettings().getResource().getPath().contains("main"));
+        Assert.assertFalse(settingsLoader.getSettings().getResource().getPath().contains("resources"));
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> settingsLoader.overrideOutputResourcesDirectory("non-existent"));
+
+        try {
+            settingsLoader.overrideOutputResourcesDirectory("src", false);
+        } catch (final Exception e) {
+            Assert.fail("This should never happened because exceptionIfNotExist = false");
+        }
+    }
+
+    @Test
+    void overrideOutputTestDirectory() {
+        final SettingsLoader settingsLoader = getSettingsLoader(null);
+        Assert.assertTrue(settingsLoader.getSettings().getTest().getPath().contains("test"));
+
+        settingsLoader.overrideOutputTestDirectory("src"); // This project "src" directory
+        Assert.assertTrue(settingsLoader.getSettings().getTest().getPath().contains("src"));
+        // Make sure it's not pointing to "killbill-plugin-framework-java/src/test/java" anymore
+        Assert.assertFalse(settingsLoader.getSettings().getTest().getPath().contains("killbill-plugin-framework-java"));
+        Assert.assertFalse(settingsLoader.getSettings().getTest().getPath().contains("test"));
+        Assert.assertFalse(settingsLoader.getSettings().getTest().getPath().contains("java"));
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> settingsLoader.overrideOutputResourcesDirectory("non-existent"));
+
+        try {
+            settingsLoader.overrideOutputTestDirectory("src", false);
+        } catch (final Exception e) {
+            Assert.fail("This should never happened because exceptionIfNotExist = false");
+        }
+    }
+}

--- a/src/test/resources/settings_with-dependency.xml
+++ b/src/test/resources/settings_with-dependency.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2022-2022 The Billing Project, LLC
+
+  The Billing Project licenses this file to you under the Apache License,
+  version 2.0 (the "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at:
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  License for the specific language governing permissions and limitations
+  under the License.
+-->
+<Settings>
+    <dependencyDirectories>
+        <dependencyDirectory>./lib</dependencyDirectory>
+    </dependencyDirectories>
+</Settings>
+


### PR DESCRIPTION
Attempt to fix: https://github.com/killbill/killbill-plugin-framework-java/issues/82

- Instead of `exec-maven-plugin`, create maven plugin, or separated script, I decided to give `api-pojos` more options and default value.
- For example, If in your current directory, you have:
  - `pojogen.jar`
  - `killbill-api` project
  - `killbill-plugin-framework-java` project
  Then calling `java -jar pojogen.jar` will generate all interfaces classes in `killbill-api` to `boilerplate` subpackage in `killbill-plugin-framework-java`. 
- See `README.md` file more explanation and options.